### PR TITLE
feat: add tauri-plugin-window-state to restore window position and size

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-plugin-fs = "2.2"
 tauri-plugin-shell = "2.2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-window-state = "2"
 notify = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "core:window:allow-hide",
     "core:window:allow-show",
     "core:window:allow-unminimize",
+    "window-state:default",
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1345,6 +1345,7 @@ fn parse_alert(line: &str) -> Option<String> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
@@ -1369,6 +1370,8 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            let window = app.get_webview_window("main").unwrap();
+            window.show()?;
             let tray = build_tray(app.handle())?;
             app.manage(TrayState(Mutex::new(Some(tray))));
             app.manage(WindowBehavior::default());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "minHeight": 600,
         "center": true,
         "decorations": false,
-        "devtools": true,
+        "devtools": false,
+        "visible": false,
         "backgroundColor": "#f5f5f5"
       }
     ],


### PR DESCRIPTION
Based on original PR #14 from andychey/feature/window-state, cherry-picked onto current master.

Changes:
- Cargo.toml: add tauri-plugin-window-state dependency
- capabilities: add window-state:default permission
- lib.rs: register plugin + window.show() in setup
- tauri.conf.json: visible: false + devtools: false