### PR TITLE
feat: reload file, scroll optimization, and line break rendering

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ class Tab {
     this.fileMeta = null;
     this.pendingExternalChange = false;
     this._loaded = true;
+    this.previewScrollTop = 0;
   }
 
   get isModified() {
@@ -2497,6 +2498,7 @@ class MarkdownEditor {
       oldTab.content = this.cm.getValue();
       oldTab.cursorPos = this.cm.getCursor();
       oldTab.scrollPos = { top: this.cm.getScrollInfo().top, left: this.cm.getScrollInfo().left };
+      oldTab.previewScrollTop = this.preview.scrollTop;
 
       this.activeTabIndex = index;
       const newTab = this.activeTab;
@@ -2506,12 +2508,22 @@ class MarkdownEditor {
       }
 
       this.cm.setValue(newTab.content || '');
+      clearTimeout(this.debounceTimer);
       this.cm.setCursor(newTab.cursorPos || { line: 0, ch: 0 });
       this.cm.scrollTo((newTab.scrollPos && newTab.scrollPos.left) || 0, (newTab.scrollPos && newTab.scrollPos.top) || 0);
       this.cm.clearHistory();
 
       this.updateTabDisplay();
       await this.updatePreview();
+      if (!this.settings.scrollSync) {
+        const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
+        this.preview.scrollTop = Math.min(newTab.previewScrollTop, maxScroll);
+      } else if (document.querySelector('.editor-container').classList.contains('preview-mode')) {
+        setTimeout(() => {
+          const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
+          this.preview.scrollTop = Math.min(newTab.previewScrollTop, maxScroll);
+        }, 0);
+      }
       this.updateWordCount();
       this.updateOutline();
       this.updateExternalChangeBanner();
@@ -3965,16 +3977,17 @@ class MarkdownEditor {
       this.cm.clearHistory();
       this.updatePreview();
       // 恢复预览滚动位置：
-      // - 非 scrollSync 模式：直接独立恢复
-      // - 预览模式（preview-mode）：编辑器隐藏导致其滚动位置不可靠，独立恢复预览位置
-      // 双重 rAF 确保在 updatePreview 的所有异步渲染（含内部 rAF 等待）完成后才恢复
-      if (!this.settings.scrollSync || document.querySelector('.editor-container').classList.contains('preview-mode')) {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
-            this.preview.scrollTop = Math.min(previewScrollTop, maxScroll);
-          });
-        });
+      // - 非 scrollSync：立即独立恢复
+      // - 预览模式 + scrollSync：延迟恢复，等滚动同步完成后覆盖
+      // - split 模式 + scrollSync：由滚动同步自动处理
+      if (!this.settings.scrollSync) {
+        const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
+        this.preview.scrollTop = Math.min(previewScrollTop, maxScroll);
+      } else if (document.querySelector('.editor-container').classList.contains('preview-mode')) {
+        setTimeout(() => {
+          const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
+          this.preview.scrollTop = Math.min(previewScrollTop, maxScroll);
+        }, 0);
       }
       this.updateWordCount();
       this.updateOutline();

--- a/src/app.js
+++ b/src/app.js
@@ -2733,6 +2733,11 @@ class MarkdownEditor {
       document.getElementById('file-menu').classList.add('hidden');
       this.saveAsFile();
     });
+    document.getElementById('btn-reload').addEventListener('click', () => this.reloadFile());
+    document.getElementById('btn-reload-menu').addEventListener('click', () => {
+      document.getElementById('file-menu').classList.add('hidden');
+      this.reloadFile();
+    });
     document.getElementById('btn-export-html').addEventListener('click', () => {
       document.getElementById('file-menu').classList.add('hidden');
       this.exportHTML();
@@ -2762,7 +2767,14 @@ class MarkdownEditor {
       document.getElementById('help-menu').classList.add('hidden');
       this.checkUpdate(true);
     });
-    document.getElementById('btn-add-tab').addEventListener('click', () => this.newFile());
+    document.getElementById('btn-devtools').addEventListener('click', () => {
+      document.getElementById('help-menu').classList.add('hidden');
+      try {
+        window.__TAURI__.core.invoke('plugin:webview|internal_toggle_devtools');
+      } catch (e) {
+        this.setStatus('无法打开开发者工具');
+      }
+    });
     document.querySelector('.tab-bar-wrapper').addEventListener('dblclick', (e) => {
       if (!e.target.closest('.tab') && !e.target.closest('.tab-add')) {
         this.newFile();
@@ -3929,6 +3941,50 @@ class MarkdownEditor {
     this.setViewMode('edit');
     this.addTab(this.t('untitled'), '', null);
     this.setStatus(this.t('newFileCreated'));
+  }
+
+  async reloadFile() {
+    const tab = this.activeTab;
+    if (!tab || !tab.filePath) {
+      this.setStatus(this.t('noFileToReload') || '当前文件无关联路径，无法重新加载');
+      return;
+    }
+    this.showLoading();
+    try {
+      const scrollInfo = this.cm.getScrollInfo();
+      const cursorPos = this.cm.getCursor();
+      const previewScrollTop = this.preview.scrollTop;
+      const content = await invoke('read_file', { path: tab.filePath });
+      tab.content = content;
+      tab.savedContent = content;
+      this.cm.setValue(content);
+      // 取消 change 事件调度的 debounced 预览更新，后续显式调用 updatePreview 替代
+      clearTimeout(this.debounceTimer);
+      this.cm.setCursor(cursorPos);
+      this.cm.scrollTo(scrollInfo.left, scrollInfo.top);
+      this.cm.clearHistory();
+      this.updatePreview();
+      // 恢复预览滚动位置：
+      // - 非 scrollSync 模式：直接独立恢复
+      // - 预览模式（preview-mode）：编辑器隐藏导致其滚动位置不可靠，独立恢复预览位置
+      // 双重 rAF 确保在 updatePreview 的所有异步渲染（含内部 rAF 等待）完成后才恢复
+      if (!this.settings.scrollSync || document.querySelector('.editor-container').classList.contains('preview-mode')) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const maxScroll = Math.max(this.preview.scrollHeight - this.preview.clientHeight, 0);
+            this.preview.scrollTop = Math.min(previewScrollTop, maxScroll);
+          });
+        });
+      }
+      this.updateWordCount();
+      this.updateOutline();
+      this.updateTabDisplay();
+      this.setStatus(`${this.t('reloaded') || '已重新加载'}: ${tab.name}`);
+    } catch (err) {
+      this.setStatus(`${this.t('reloadFailed') || '重新加载失败'}: ${err}`);
+    } finally {
+      this.hideLoading();
+    }
   }
 
   async openFile() {

--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,15 @@
                 <span class="shortcut"></span>
               </div>
               <div class="dropdown-separator"></div>
+              <div class="dropdown-item" id="btn-reload-menu">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="23 4 23 10 17 10"/>
+                  <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+                </svg>
+                <span>重新加载</span>
+                <span class="shortcut">Ctrl+R</span>
+              </div>
+              <div class="dropdown-separator"></div>
               <div class="dropdown-item" id="btn-export-html">
                 <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
                 <span>导出 HTML</span>
@@ -105,6 +114,12 @@
                 <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
                 <span>检查更新</span>
               </div>
+              <div class="dropdown-separator"></div>
+              <div class="dropdown-item" id="btn-devtools">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                <span>开发者工具</span>
+                <span class="shortcut">Ctrl+Shift+I</span>
+              </div>
               <div class="dropdown-item" id="btn-about">
                 <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
                 <span>关于</span>
@@ -125,6 +140,12 @@
           </div>
         </div>
         <div class="toolbar-right">
+          <button id="btn-reload" class="toolbar-btn" title="重新加载文件">
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="23 4 23 10 17 10"/>
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+            </svg>
+          </button>
           <button id="btn-theme" class="toolbar-btn" title="切换主题">
             <svg class="icon" id="theme-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="4"/>

--- a/src/lib/unified-bundle.js
+++ b/src/lib/unified-bundle.js
@@ -23753,6 +23753,24 @@ var UnifiedRenderer = (() => {
           });
         };
       }
+      function remarkBreaks() {
+        return (tree) => {
+          visit2(tree, "text", (node, index, parent) => {
+            if (parent && (parent.type === "paragraph" || parent.type === "heading")) {
+              const parts = node.value.split("\n");
+              if (parts.length > 1) {
+                const children = [];
+                for (let i = 0; i < parts.length; i++) {
+                  if (i > 0) children.push({ type: "break" });
+                  if (parts[i] !== "") children.push({ type: "text", value: parts[i] });
+                }
+                parent.children.splice(index, 1, ...children);
+                return index + children.length;
+              }
+            }
+          });
+        };
+      }
       function guardMathBlocks(content3) {
         const placeholders = [];
         let result = "";
@@ -24342,7 +24360,7 @@ var UnifiedRenderer = (() => {
         processed = convertContainerTables(processed);
         let html7;
         try {
-          const processor = unified2().use(remarkParse2).use(remarkGfm2, { singleTilde: false }).use(remarkSourceLine);
+          const processor = unified2().use(remarkParse2).use(remarkGfm2, { singleTilde: false }).use(remarkSourceLine).use(remarkBreaks);
           if (softBreaks) {
             processor.use(remarkSoftBreaks);
           }

--- a/src/unified-renderer.js
+++ b/src/unified-renderer.js
@@ -664,6 +664,27 @@ function convertHighlights(html) {
 // separate softbreak nodes, so we split text nodes on "\n" and insert
 // <br> between the fragments. Inline code / fenced code are untouched
 // because their content lives in `.value`, not in `.children`.
+// remarkBreaks: convert \n inside paragraphs/headings to <br>
+// Always active — handles single-line breaks within block-level text.
+function remarkBreaks() {
+  return (tree) => {
+    visit(tree, 'text', (node, index, parent) => {
+      if (parent && (parent.type === 'paragraph' || parent.type === 'heading')) {
+        const parts = node.value.split('\n');
+        if (parts.length > 1) {
+          const children = [];
+          for (let i = 0; i < parts.length; i++) {
+            if (i > 0) children.push({ type: 'break' });
+            if (parts[i] !== '') children.push({ type: 'text', value: parts[i] });
+          }
+          parent.children.splice(index, 1, ...children);
+          return index + children.length;
+        }
+      }
+    });
+  };
+}
+
 function remarkSoftBreaks() {
   return (tree) => {
     const toBr = () => ({ type: 'html', value: '<br>' });
@@ -727,7 +748,8 @@ function renderMarkdown(content, options) {
     const processor = unified()
       .use(remarkParse)
       .use(remarkGfm, { singleTilde: false })
-      .use(remarkSourceLine);
+      .use(remarkSourceLine)
+      .use(remarkBreaks);
     if (softBreaks) {
       processor.use(remarkSoftBreaks);
     }


### PR DESCRIPTION
Based on original PR #6 from ligongjian/master, 3 unique commits cherry-picked.

### Changes
- **Reload file**: new reloadFile() method, reads from disk and restores cursor/scroll position, Ctrl+R shortcut
- **DevTools entry**: Developer Tools button in help menu
- **Preview scroll restoration**: Tab class now tracks previewScrollTop, restored correctly on tab switch and file load
- **remarkBreaks plugin**: converts line breaks in paragraphs/headings to <br> elements, coexists with existing softBreaks