### PR TITLE
feat: 拖拽文件/文件夹到桌面图标即可打开

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,6 +374,11 @@ fn file_meta(path: String) -> Result<Option<FileMeta>, String> {
     }))
 }
 
+#[tauri::command]
+fn is_directory(path: String) -> bool {
+    std::path::Path::new(&path).is_dir()
+}
+
 #[derive(serde::Serialize, Clone)]
 struct DirEntryInfo {
     name: String,
@@ -1353,7 +1358,10 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             if let Some(window) = app.get_webview_window("main") {
                 show_window(&window);
-                let _ = app.emit("file-open", argv);
+                // 插件转发的 argv 含 argv[0]（第二实例 exe 自身路径），滤掉，
+                // 避免前端误把 exe 当文件打开；与 get_cli_args 的 skip(1) 对齐
+                let args: Vec<String> = argv.into_iter().skip(1).collect();
+                let _ = app.emit("file-open", args);
             }
         }))
         .on_window_event(|window, event| {
@@ -1386,6 +1394,7 @@ pub fn run() {
             read_file,
             write_file,
             file_meta,
+            is_directory,
             list_dir,
             write_binary_file,
             ensure_dir,

--- a/src/app.js
+++ b/src/app.js
@@ -3687,8 +3687,22 @@ class MarkdownEditor {
         this.showLoading();
         try {
           const paths = event.payload.paths || [];
+          let dirOpened = false;
           for (const filePath of paths) {
             try {
+              // 先判断是否目录：是目录则加载为工作区（只取第一个目录，多目录时其余忽略并提示）
+              let isDir = false;
+              try { isDir = await invoke('is_directory', { path: filePath }); }
+              catch (_) { /* 非 Tauri 环境或路径不存在，按文件处理 */ }
+              if (isDir) {
+                if (dirOpened) {
+                  this.setStatus(`${this.t('openFailed')}: ${filePath}`);
+                  continue;
+                }
+                dirOpened = true;
+                await this.openFolderPath(filePath);
+                continue;
+              }
               const content = await this.readFileNormalized(filePath);
               const name = filePath.split(/[/\\]/).pop();
               const existingIndex = this.tabs.findIndex(t => t.filePath === filePath);
@@ -4257,7 +4271,18 @@ class MarkdownEditor {
       if (!selected) return;
       const folderPath = Array.isArray(selected) ? selected[0] : selected;
       if (!folderPath) return;
-      this.showLoading();
+      await this.openFolderPath(folderPath);
+    } catch (e) {
+      this.setStatus(this.t('openFailed') + ': ' + e);
+    }
+  }
+
+  // 直接按给定路径加载为工作区目录（不走 dialog）。
+  // CLI 参数 / file-open 事件 / drag-drop 都复用此入口。
+  async openFolderPath(folderPath) {
+    if (!folderPath) return;
+    this.showLoading();
+    try {
       this.workspaceFolder = folderPath;
       this.expandedFolders = new Set();
       await this.renderFolderTree();
@@ -7145,9 +7170,20 @@ window.addEventListener('DOMContentLoaded', async () => {
 
       window.editor.showLoading();
       try {
+        let dirOpened = false;
         for (const filePath of args) {
           if (filePath.startsWith('-')) continue;
-          await window.editor.openFilePath(filePath);
+          let isDir = false;
+          try { isDir = await invoke('is_directory', { path: filePath }); }
+          catch (_) { /* 路径不存在或不可访问，按文件处理 */ }
+          if (isDir) {
+            // 只接受第一个目录作为工作区，多目录时后续忽略
+            if (dirOpened) continue;
+            dirOpened = true;
+            await window.editor.openFolderPath(filePath);
+          } else {
+            await window.editor.openFilePath(filePath);
+          }
         }
       } finally {
         window.editor.hideLoading();
@@ -7159,9 +7195,19 @@ window.addEventListener('DOMContentLoaded', async () => {
       const args = await invoke('get_cli_args');
       const hadSession = await window.editor.restoreSession();
       if (args && args.length > 0) {
+        let dirOpened = false;
         for (const filePath of args) {
           if (filePath.startsWith('-')) continue;
-          await window.editor.openFilePath(filePath);
+          let isDir = false;
+          try { isDir = await invoke('is_directory', { path: filePath }); }
+          catch (_) { /* 路径不存在或不可访问，按文件处理 */ }
+          if (isDir) {
+            if (dirOpened) continue;
+            dirOpened = true;
+            await window.editor.openFolderPath(filePath);
+          } else {
+            await window.editor.openFilePath(filePath);
+          }
         }
       } else if (!hadSession && isFirstLaunch) {
         window.editor.openUserGuide();


### PR DESCRIPTION
- lib.rs: 新增 is_directory 命令；single-instance 转发 argv 时过滤 argv[0]，修复误把 exe 当文件打开导致的 openFailed 闪烁（双击 .md 场景同样受益）
- app.js: 拆出 openFolderPath() 供启动 CLI 参数、file-open 事件、窗口 drag-drop 三处复用；三处入口按 is_directory 分发——目录加载为工作区（多目录取第一个），文件只开 tab 不动工作区