### PR TITLE
fix: 修复预览区 Ctrl+C 被文件树操作劫持，右键菜单补快捷键提示

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4598,7 +4598,7 @@ class MarkdownEditor {
       // 文件树右键菜单快捷键（合并自 PR #36）：_fileTreeCtx 存在时，F2/Delete/Ctrl+X/C/V 对其生效。
       // 关键修复：点击文件打开后焦点落在编辑器（.CodeMirror），旧逻辑用「!inEditor」拦截导致
       // Ctrl+C/V 被 CodeMirror 吞掉、文件复制/粘贴「不起作用」。现改为：Ctrl+C/X/V 以文件树操作为先，
-      // 仅当编辑器存在文本选区时才让位给编辑器的文本复制/剪切/粘贴（cm.somethingSelected()）。
+      // 仅当编辑器或预览区存在文本选区时才让位给文本复制/剪切/粘贴。
       // 用户真正点进编辑器编辑时（editorWrapper mousedown）会清掉 _fileTreeCtx，恢复纯文本操作。
       if (this._fileTreeCtx) {
         const inInput = e.target.closest('input, textarea, select');
@@ -4608,17 +4608,21 @@ class MarkdownEditor {
           if (e.key === 'Delete') { e.preventDefault(); this.fileTreeDelete(); return; }
           if (ctrl && !e.shiftKey && !e.altKey) {
             const k = e.key.toLowerCase();
-            // 复制 / 剪切：编辑器有文本选区时交给编辑器；否则按文件树复制/剪切
+            // 检查编辑器或预览区是否有文本选区——有选区时交给浏览器原生 copy/cut，
+            // 不走文件树操作。预览区是 HTML 内容，window.getSelection() 检测其选区。
+            const hasTextSelection = (this.cm && this.cm.somethingSelected())
+              || (window.getSelection && window.getSelection().toString().length > 0);
+            // 复制 / 剪切：有文本选区时交给编辑器/浏览器；否则按文件树复制/剪切
             if (k === 'x' || k === 'c') {
-              if (this.cm && this.cm.somethingSelected()) return;
+              if (hasTextSelection) return;
               e.preventDefault();
               if (k === 'c') this.fileTreeCopy(); else this.fileTreeCut();
               return;
             }
-            // 粘贴：文件树选中节点（目录或文件）且编辑器无文本选区时，粘贴文件。
-            // 选中目录→粘贴进该目录；选中文件→粘贴进其所在目录（同级）。编辑器有选区时交给文本粘贴。
+            // 粘贴：文件树选中节点（目录或文件）且无文本选区时，粘贴文件。
+            // 选中目录→粘贴进该目录；选中文件→粘贴进其所在目录（同级）。有文本选区时交给文本粘贴。
             if (k === 'v') {
-              if (!(this.cm && this.cm.somethingSelected())) {
+              if (!hasTextSelection) {
                 e.preventDefault();
                 this.fileTreePaste();
               }

--- a/src/index.html
+++ b/src/index.html
@@ -1158,8 +1158,8 @@
 
   <!-- 预览区域右键菜单 -->
   <div id="context-menu-preview" class="context-menu hidden">
-    <div class="context-menu-item" data-action="preview-copy"><span>复制</span></div>
-    <div class="context-menu-item" data-action="preview-select-all"><span>全选</span></div>
+    <div class="context-menu-item" data-action="preview-copy"><span>复制</span><span class="shortcut">Ctrl+C</span></div>
+    <div class="context-menu-item" data-action="preview-select-all"><span>全选</span><span class="shortcut">Ctrl+A</span></div>
     <div class="context-menu-separator"></div>
     <div class="context-menu-item" data-action="preview-copy-html"><span>复制为 HTML</span></div>
     <div class="context-menu-separator"></div>


### PR DESCRIPTION
## 问题

当用户在文件树点击文件后切到预览区选中文字按 Ctrl+C，快捷键被文件树复制操作劫持，选中的文字无法复制到剪贴板。同时预览区右键菜单的「复制」「全选」缺少快捷键提示。

## 原因

旧逻辑在判断 Ctrl+C/X/V 是执行文件树操作还是文本操作时，仅检查编辑器（CodeMirror）是否有选区（`cm.somethingSelected()`），不检查预览区的 `window.getSelection()`。预览区是只读 HTML 内容，其选区只能通过 `window.getSelection()` 获取。

## 修复

```javascript
// 改前：只检查编辑器
const hasTextSelection = this.cm && this.cm.somethingSelected();

// 改后：编辑器或预览区有选区都算
const hasTextSelection = (this.cm && this.cm.somethingSelected())
  || (window.getSelection && window.getSelection().toString().length > 0);
```

有文本选区时 Ctrl+C/X 放行给浏览器原生 `copy`/`cut` 事件处理，与编辑区完全一致的机制。

另外给预览区右键菜单的「复制」「全选」补充了 `Ctrl+C` / `Ctrl+A` 快捷键提示，与编辑器右键菜单保持一致。

Resolve #43. Resolve #47.