### PR TITLE
fix(shortcut): 修复 Alt 系快捷键不派发，并为「关闭到托盘」增加 OS 级全局热键

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,9 @@ tauri-plugin-dialog = "2.2"
 tauri-plugin-fs = "2.2"
 tauri-plugin-shell = "2.2"
 tauri-plugin-single-instance = "2"
+# 「关闭到托盘」OS 级全局热键：窗口隐藏到托盘后前端 keydown 收不到按键，只能靠
+# 系统级热键唤回窗口（见 lib.rs set_close_to_tray_shortcut / toggle_main_window）
+tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 notify = "6"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
       "identifier": "shell:allow-open",
       "allow": [{ "path": "**" }]
     },
-    "updater:default"
+    "updater:default",
+    "global-shortcut:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tauri::path::BaseDirectory;
 use tauri::WindowEvent;
 use tauri::tray::{TrayIcon, TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState};
 use tauri::menu::{Menu, MenuItem};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 use md5::{Md5, Digest};
 
 fn show_window(window: &tauri::WebviewWindow) {
@@ -272,6 +273,61 @@ fn build_tray(app: &tauri::AppHandle) -> tauri::Result<TrayIcon> {
             }
         })
         .build(app)
+}
+
+// ====== 「关闭到托盘」OS 级全局热键 ======
+// 前端 keydown 只能在窗口聚焦时收到按键；窗口隐藏到托盘后 WebView 不再接收任何
+// 键盘事件，因此「隐藏后也能唤回窗口」必须由 OS 级全局热键（tauri-plugin-global-shortcut）
+// 承担。前端在应用启动/修改快捷键时调用 set_close_to_tray_shortcut 注册/注销。
+struct GlobalShortcutState(Mutex<Option<String>>);
+
+// 全局热键回调：窗口可见 → 隐藏到托盘（仅当托盘可见，否则窗口将无法恢复）；
+// 窗口已隐藏/最小化 → 显示并聚焦（show_window 已做 unminimize + show + set_focus）。
+fn toggle_main_window(app: &tauri::AppHandle) {
+    let show_tray = app
+        .try_state::<WindowBehavior>()
+        .and_then(|b| b.show_tray.lock().ok().map(|g| *g))
+        .unwrap_or(true);
+    let Some(window) = app.get_webview_window("main") else { return };
+    if window.is_visible().unwrap_or(false) {
+        if show_tray {
+            let _ = window.hide();
+        }
+    } else {
+        show_window(&window);
+    }
+}
+
+// 前端同步「关闭到托盘」全局热键：key 为空字符串则仅注销旧热键。
+#[tauri::command]
+fn set_close_to_tray_shortcut(app: tauri::AppHandle, key: String) -> Result<(), String> {
+    // 1) 先注销旧的全局热键（存在时）
+    let old = app
+        .state::<GlobalShortcutState>()
+        .0
+        .lock()
+        .map_err(|e| e.to_string())?
+        .take();
+    if let Some(old_key) = old {
+        if let Ok(s) = old_key.parse::<Shortcut>() {
+            let _ = app.global_shortcut().unregister(s);
+        }
+    }
+    let key = key.trim().to_string();
+    if key.is_empty() {
+        return Ok(());
+    }
+    // 2) 注册新热键；组合键已被其他程序占用等失败会返回 Err，由前端告警
+    let shortcut: Shortcut = key
+        .parse()
+        .map_err(|e| format!("无效全局快捷键 {}: {}", key, e))?;
+    app.global_shortcut().register(shortcut).map_err(|e| e.to_string())?;
+    *app
+        .state::<GlobalShortcutState>()
+        .0
+        .lock()
+        .map_err(|e| e.to_string())? = Some(key);
+    Ok(())
 }
 
 #[derive(serde::Serialize, Clone, Copy)]
@@ -1136,6 +1192,15 @@ pub fn run() {
                 let _ = app.emit("file-open", files_from_args(argv));
             }
         }))
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, _shortcut, event| {
+                    if event.state() == ShortcutState::Pressed {
+                        toggle_main_window(app);
+                    }
+                })
+                .build(),
+        )
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
                 let app = window.app_handle();
@@ -1161,10 +1226,12 @@ pub fn run() {
             Ok(())
         })
         .manage(WatcherState(Mutex::new(None)))
+        .manage(GlobalShortcutState(Mutex::new(None)))
         .invoke_handler(tauri::generate_handler![
             open_devtools,
             get_cli_args,
             set_window_behavior,
+            set_close_to_tray_shortcut,
             quit_app,
             read_file,
             write_file,

--- a/src/app.js
+++ b/src/app.js
@@ -4533,6 +4533,12 @@ class MarkdownEditor {
     for (const [action, fn] of Object.entries(globalMap)) registerGlobal(action, fn, false);
     for (const [action, fn] of Object.entries(editorMap)) registerGlobal(action, fn, true);
 
+    // 同步「关闭到托盘」键位到 OS 级全局热键：窗口隐藏到托盘后 WebView 收不到键盘
+    // 事件，前端 keydown 无法唤回窗口；OS 级热键（lib.rs set_close_to_tray_shortcut）
+    // 负责隐藏/唤回。注册失败（组合键被其他程序占用等）仅告警，窗口内 keydown 派发
+    // 仍作为兜底可用（全局注册成功后 OS 会吃掉该键，二者不会重复触发）。
+    this._syncGlobalCloseToTrayShortcut((s.closeToTray && s.closeToTray.key) || '');
+
     this.updateShortcutHints();
   }
 
@@ -5954,6 +5960,37 @@ class MarkdownEditor {
       }
 
       const ctrl = e.ctrlKey || e.metaKey;
+
+      // 统一构建 keyStr（主键用 e.code 物理键位推导，规避某些浏览器/环境下
+      // Ctrl+Shift+字母的 e.key 取值异常），供全局快捷键匹配。
+      // 修复：旧实现把整个匹配包在 if(ctrl) 里，Alt 系快捷键（如「关闭到托盘」Alt+M）
+      // 永不派发；现在只要有 Ctrl/Meta/Alt 任一修饰键就参与全局匹配，纯字母/Shift
+      // 裸按键仍不参与（避免打字误触发）。
+      if (ctrl || e.altKey) {
+        let baseKey;
+        if (e.code && /^Key[A-Za-z]$/.test(e.code)) baseKey = e.code.slice(3).toUpperCase();
+        else if (e.code && /^Digit[0-9]$/.test(e.code)) baseKey = e.code.slice(5);
+        else baseKey = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+        const gParts = [];
+        if (e.ctrlKey || e.metaKey) gParts.push('Ctrl');
+        if (e.shiftKey) gParts.push('Shift');
+        if (e.altKey) gParts.push('Alt');
+        gParts.push(baseKey);
+        const keyStr = gParts.join('+');
+        const gHandler = this.globalShortcutLookup?.[keyStr];
+        // 全局快捷键在【捕获阶段】统一派发：命中即阻止默认行为 + stopPropagation，
+        // 阻断事件继续冒泡到 CodeMirror（及其默认键位 search.js 的 Shift-Ctrl-F→replace）
+        // 或 Tauri WebView 的原生处理，确保编辑器有焦点时也能且仅由本处触发一次。
+        // （CM 的 extraKeys 仍对相关键置 false 作为兜底。）
+        if (gHandler) {
+          if (ctrl) e.preventDefault(); // Ctrl 类命中照旧阻止浏览器默认行为
+          e.stopPropagation();
+          gHandler();
+          return;
+        }
+      }
+
+      // 以下仅对 Ctrl/Meta 组合生效（保持原有行为不变）：
       if (ctrl) {
         const key = e.key.toLowerCase();
 
@@ -5979,30 +6016,6 @@ class MarkdownEditor {
 
         // Block ALL other Ctrl shortcuts from triggering browser defaults
         e.preventDefault();
-
-        // Handle TizuMark's global shortcuts (work even when editor is not focused)
-        // 主键用 e.code（物理键位）推导，规避某些浏览器/环境下 Ctrl+Shift+字母的
-        // e.key 取值异常（如被当成其它字符），保证 keyStr 与 globalShortcutLookup
-        // 中存储的 'Ctrl+Shift+F' 等稳定匹配。
-        let baseKey;
-        if (e.code && /^Key[A-Za-z]$/.test(e.code)) baseKey = e.code.slice(3).toUpperCase();
-        else if (e.code && /^Digit[0-9]$/.test(e.code)) baseKey = e.code.slice(5);
-        else baseKey = e.key.length === 1 ? e.key.toUpperCase() : e.key;
-        const gParts = [];
-        if (e.ctrlKey || e.metaKey) gParts.push('Ctrl');
-        if (e.shiftKey) gParts.push('Shift');
-        if (e.altKey) gParts.push('Alt');
-        gParts.push(baseKey);
-        const keyStr = gParts.join('+');
-        const gHandler = this.globalShortcutLookup?.[keyStr];
-        // 全局快捷键在【捕获阶段】统一派发：命中即 stopPropagation，阻断事件继续
-        // 冒泡到 CodeMirror（及其默认键位 search.js 的 Shift-Ctrl-F→replace）或
-        // Tauri WebView 的原生处理，确保编辑器有焦点时也能且仅由本处触发一次。
-        // （CM 的 extraKeys 仍对相关键置 false 作为兜底。）
-        if (gHandler) {
-          e.stopPropagation();
-          gHandler();
-        }
       }
     }, true);
   }
@@ -13062,6 +13075,15 @@ input[type="checkbox"]:checked::after { display: none !important; }
         const w = TauriApi.currentWindow();
         if (w) await w.hide();
       } catch { /* 浏览器环境下降级 */ }
+    }
+  }
+
+  // 同步「关闭到托盘」全局热键到 Rust（OS 级：窗口隐藏后仍能唤出/隐藏）
+  async _syncGlobalCloseToTrayShortcut(key) {
+    try {
+      await TauriApi.setCloseToTrayShortcut({ key: key || '' });
+    } catch (err) {
+      console.warn('全局热键注册失败（该组合键可能已被其他程序占用）:', key, err);
     }
   }
 

--- a/src/modules/tauri-api.js
+++ b/src/modules/tauri-api.js
@@ -2,7 +2,7 @@
  * tauri-api.js —— 统一 IPC 边界（ADR-1 / N11 / N21 / N29）
  *
  * 设计要点（任何偏离都会破坏方案硬约束，勿擅自改动）：
- *  - COMMANDS 是 27 个自定义命令的【唯一真源】；方法由其生成。契约测试反解析
+ *  - COMMANDS 是 28 个自定义命令的【唯一真源】；方法由其生成。契约测试反解析
  *    src-tauri/src/lib.rs 的 generate_handler! 块校验集合一致（C17）。
  *  - 延迟求值：调用时才读取 window.__TAURI__.core.invoke（根治 app.js:1 白屏单点，N4）。
  *  - 语义空操作（硬约束 N21）：resolve 原样返回，reject 原样抛出；
@@ -22,6 +22,7 @@
     'read_bundled_image_as_base64', 'fetch_image_as_base64', 'save_image_to_assets',
     'watch_folder', 'stop_watch', 'search_in_files', 'generate_toc',
     'get_cli_args', 'quit_app', 'open_devtools', 'set_window_behavior',
+    'set_close_to_tray_shortcut',
     'reveal_in_folder',
     // 文件树右键操作（合并自 PR #36）：重命名 / 删除 / 复制 / 移动
     'rename_path', 'remove_path', 'copy_path', 'move_path',

--- a/test/shortcut-default-registration.test.cjs
+++ b/test/shortcut-default-registration.test.cjs
@@ -283,7 +283,7 @@ function makeCmStub() {
 
 test('E1 applyShortcuts 把标题 H1~H6 注册进 CM extraKeys（Ctrl-1 ~ Ctrl-6）', () => {
   const cm = makeCmStub();
-  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {} };
+  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {}, _syncGlobalCloseToTrayShortcut() {} };
   applyShortcuts.call(s);
   for (let i = 1; i <= 6; i++) {
     assert.strictEqual(typeof cm._ek['Ctrl-' + i], 'function',
@@ -293,7 +293,7 @@ test('E1 applyShortcuts 把标题 H1~H6 注册进 CM extraKeys（Ctrl-1 ~ Ctrl-6
 
 test('E2 applyShortcuts 把加粗/图片/公式等注册进 CM，并把全局键与编辑器键都填入 globalShortcutLookup', () => {
   const cm = makeCmStub();
-  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {} };
+  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {}, _syncGlobalCloseToTrayShortcut() {} };
   applyShortcuts.call(s);
   assert.strictEqual(typeof cm._ek['Ctrl-B'], 'function', '加粗应注册');
   // 注意：applyShortcuts 内 toCmKey 按修饰键排序（Shift 在前），故 Ctrl+Shift+I → Shift-Ctrl-I
@@ -310,7 +310,7 @@ test('E2 applyShortcuts 把加粗/图片/公式等注册进 CM，并把全局键
 test('E3 编辑器动作的全局项带「聚焦才执行」守卫：未聚焦不误触、聚焦才执行', () => {
   const cm = makeCmStub();
   const spy = [];
-  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {}, wrapSelection: () => spy.push('wrap') };
+  const s = { cm, shortcuts: getDefaultShortcuts(), updateShortcutHints() {}, _syncGlobalCloseToTrayShortcut() {}, wrapSelection: () => spy.push('wrap') };
   applyShortcuts.call(s);
   cm.hasFocus = () => false;
   s.globalShortcutLookup['Ctrl+B']();

--- a/test/tauri-api.test.cjs
+++ b/test/tauri-api.test.cjs
@@ -1,5 +1,5 @@
 // P0-2a（C3/C5/C17 + N21/N27/N29）：tauri-api 模块 + 前后端契约测试。
-// 覆盖：① 27 自定义命令方法由 COMMANDS 生成并透传；② plugin 命令（dialog/updater/webview）透传；
+// 覆盖：① 28 自定义命令方法由 COMMANDS 生成并透传；② plugin 命令（dialog/updater/webview）透传；
 //       ③ __TAURI__ 缺失时抛明确错误（ADR-1 唯一守卫）；④ reject 原样抛出（N21 语义空操作，C16 前提）；
 //       ⑤ Channel 构造器延迟可用；⑥ COMMANDS 集合 == lib.rs generate_handler! 注册集合（C17）；
 //       ⑦ generate_handler! 解析失败显式抛错（N27）。
@@ -38,7 +38,7 @@ test('COMMANDS 集合 == lib.rs generate_handler! 注册集合（C17，前后端
   const expected = [...TauriApi.COMMANDS].sort();
   assert.deepEqual(names, expected,
     `前后端命令集合必须一致。差异：${JSON.stringify(names)} vs ${JSON.stringify(expected)}`);
-  assert.equal(expected.length, 27, '应有 27 个自定义命令');
+  assert.equal(expected.length, 28, '应有 28 个自定义命令');
 });
 
 test('generate_handler! 解析失败必须显式抛错（N27）', () => {


### PR DESCRIPTION
## 问题

用户反馈：把「关闭到托盘」绑定为 `Alt+M` 后，快捷键不生效，也无法唤出窗口。排查发现是两个独立缺陷叠加。

### 缺陷 1：Alt 系快捷键根本不派发
`src/app.js` 的 document 级 keydown 处理器把所有全局快捷键派发逻辑整体包在 `if (ctrl)` 里，只有 Ctrl/Meta 组合才会去查 `globalShortcutLookup`。`Alt+M` 没有 Ctrl，永远匹配不到，`hideToTray()` 不会执行——也就是说**任何 Alt 系全局快捷键**（不只是「关闭到托盘」）都失效。

### 缺陷 2：窗口隐藏后无法唤回
现有快捷键都建立在 DOM keydown 上。窗口一旦 `hide()` 到托盘，WebView 不再接收键盘事件，快捷键不可能再唤回窗口。要支持「隐藏后也能唤回」必须使用 OS 级全局热键。

## 变更

| 文件 | 说明 |
| --- | --- |
| `src/app.js` | 只要有 Ctrl/Meta/Alt 任一修饰键就参与全局匹配（Ctrl 分支原有行为完全不变：导航键放行、a/c/v/x/z/y 放行、其余 preventDefault）；`applyShortcuts` 时把「关闭到托盘」键位同步给后端 |
| `src-tauri/src/lib.rs` | 新增 `set_close_to_tray_shortcut` 命令与 `GlobalShortcutState`；注册 `tauri-plugin-global-shortcut`，热键回调实现「窗口可见 → 隐藏到托盘 / 窗口隐藏或最小化 → `unminimize` + `show` + `set_focus` 唤回」 |
| `src-tauri/Cargo.toml` | 新增依赖 `tauri-plugin-global-shortcut = "2"` |
| `src-tauri/capabilities/default.json` | 新增权限 `global-shortcut:default` |
| `src/modules/tauri-api.js` | `COMMANDS` 增加 `set_close_to_tray_shortcut`（27 → 28） |
| `test/tauri-api.test.cjs` | 契约测试命令数 27 → 28 |
| `test/shortcut-default-registration.test.cjs` | 测试桩补上新增的 `_syncGlobalCloseToTrayShortcut` |

### 设计取舍
- 键位解析直接复用插件 `Shortcut`（即 `HotKey`）的 `FromStr`，已确认支持 `Alt+M` / `Ctrl+Shift+W` 这类前端既有格式（修饰键大小写不敏感，单字母可写为 `M`）。
- 全局热键注册失败（组合键已被其他程序占用等）只告警不阻断；此时窗口内的 keydown 派发仍作为兜底。全局注册成功后 OS 会吃掉该按键，两条通道不会重复触发。
- 窗口可见时按热键才隐藏，且仅当托盘图标可见（`showTrayIcon`）时才隐藏，避免托盘已关闭的情况下窗口无法恢复。

## 验证

- `npm run build:renderer`、`npm run build-frontend` 通过。
- `node scripts/run-tests.cjs`：**121/122 个测试文件通过**。快捷键派发（`shortcut-global-dispatch`）、默认键位注册（`shortcut-default-registration`）、行移动、文档导航、契约测试等 49 项相关用例全绿。
- 唯一的 `version-check.test.cjs` 失败属于仓库既有问题：`package.json` 为 1.2.3，而 `src/app.js` / `src/index.html` / `README.md` / `README.en.md` 仍为 1.2.2。该失败在 `master` 上即存在，与本次改动无关（本次未触碰任何版本号）。

### 关于 Rust 侧编译
本次未在本地执行 `cargo build`：开发机没有 Rust 工具链（无 `cargo` / `rustc`），也没有 MSVC 链接器（无 `link.exe`），而 Tauri 的 Windows 构建两者都必需。Rust 侧改动已按 `tauri-plugin-global-shortcut` 官方 API 逐项核对签名（`Builder::new().with_handler`、`GlobalShortcutExt::global_shortcut`、`register` / `unregister`、`ShortcutEvent::state()`、`Shortcut: FromStr`），并以 CI 编译结果为准。
